### PR TITLE
feat(config): add multi-env config system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint test validate-structure docker-up generate-protos test-shared
+.PHONY: setup lint test validate-structure docker-up generate-protos test-shared validate-config test-vault-integration
 
 setup:
 	pip install --upgrade pip
@@ -21,4 +21,8 @@ generate-protos:
 	bash tools/scripts/generate_protos.sh
 
 test-shared:
-	PYTHONPATH=. pytest --cov=shared --cov-report=term-missing
+        PYTHONPATH=. pytest --cov=shared --cov-report=term-missing
+validate-config:
+	PYTHONPATH=. python tools/config-validator.py
+test-vault-integration:
+	PYTHONPATH=. pytest tests/config/test_vault.py --cov=shared/config --cov-report=term-missing

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,0 +1,12 @@
+app:
+  name: alphaflow-local
+  log_level: DEBUG
+
+database:
+  host: localhost
+  port: 5432
+  name: alphaflow_local
+
+redis:
+  host: localhost
+  port: 6379

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,0 +1,12 @@
+app:
+  name: alphaflow
+  log_level: WARNING
+
+database:
+  host: prod-db
+  port: 5432
+  name: alphaflow
+
+redis:
+  host: prod-redis
+  port: 6379

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,0 +1,12 @@
+app:
+  name: alphaflow-staging
+  log_level: INFO
+
+database:
+  host: staging-db
+  port: 5432
+  name: alphaflow_staging
+
+redis:
+  host: staging-redis
+  port: 6379

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ pytest
 pytest-cov
 grpcio-tools
 jsonschema
+pyyaml
+hvac
+watchdog
+pytest-asyncio

--- a/shared/config/__init__.py
+++ b/shared/config/__init__.py
@@ -1,0 +1,31 @@
+"""Configuration utilities."""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from .loader import ConfigLoader, ConfigError
+from .reloader import ConfigReloader
+
+__all__ = [
+    "ConfigLoader",
+    "ConfigError",
+    "ConfigReloader",
+    "get_config_loader",
+    "load_config",
+]
+
+
+def get_config_loader() -> ConfigLoader:
+    """Return loader based on ALPHAFLOW_ENV."""
+    env = os.getenv("ALPHAFLOW_ENV", "local")
+    config_dir = Path(os.getenv("CONFIG_DIR", "config"))
+    return ConfigLoader(env=env, config_dir=config_dir)
+
+
+async def load_config() -> Dict[str, Any]:
+    """Convenience to load config asynchronously."""
+    loader = get_config_loader()
+    return await loader.load()

--- a/shared/config/loader.py
+++ b/shared/config/loader.py
@@ -1,0 +1,54 @@
+"""Config loader with Vault integration and validation."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+from jsonschema import validate, ValidationError
+
+from .vault import VaultClient, VaultError
+from .schema import CONFIG_SCHEMA
+
+
+class ConfigError(Exception):
+    """Configuration loading failure."""
+
+
+@dataclass
+class ConfigLoader:
+    """Load and validate configuration."""
+
+    env: str
+    config_dir: Path = Path("config")
+    vault_client: Optional[VaultClient] = None
+
+    async def _read_file(self, path: Path) -> Dict[str, Any]:
+        data = await asyncio.to_thread(path.read_text)
+        return yaml.safe_load(data)
+
+    async def _load_secrets(self) -> Dict[str, Any]:
+        if not self.vault_client:
+            return {}
+        secrets = {}
+        for key in ("api_key", "db_password"):
+            secret = await self.vault_client.get_secret(f"alphaflow/{self.env}", key)
+            secrets[key] = secret
+        return secrets
+
+    async def load(self) -> Dict[str, Any]:
+        path = self.config_dir / f"{self.env}.yaml"
+        if not path.exists():
+            raise ConfigError(f"Config file {path} missing")
+        cfg = await self._read_file(path)
+        try:
+            validate(cfg, CONFIG_SCHEMA)
+        except ValidationError as exc:
+            raise ConfigError(str(exc)) from exc
+        secrets = await self._load_secrets()
+        cfg.update(secrets)
+        if "api_key" not in cfg or "db_password" not in cfg:
+            raise ConfigError("Missing critical configuration")
+        return cfg

--- a/shared/config/reloader.py
+++ b/shared/config/reloader.py
@@ -1,0 +1,36 @@
+"""Config hot reloading utility."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Dict
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from .loader import ConfigLoader
+
+
+class ConfigReloader(FileSystemEventHandler):
+    """Watch config file and reload on change."""
+
+    def __init__(self, loader: ConfigLoader, callback: Callable[[Dict[str, Any]], None]):
+        self._loader = loader
+        self._callback = callback
+        self._observer = Observer()
+
+    def start(self) -> None:
+        path = self._loader.config_dir / f"{self._loader.env}.yaml"
+        self._observer.schedule(self, path=path.parent, recursive=False)
+        self._observer.start()
+
+    def stop(self) -> None:
+        self._observer.stop()
+        self._observer.join()
+
+    def on_modified(self, event) -> None:  # type: ignore[override]
+        if not event.is_directory:
+            asyncio.create_task(self._reload())
+
+    async def _reload(self) -> None:
+        cfg = await self._loader.load()
+        self._callback(cfg)

--- a/shared/config/schema.py
+++ b/shared/config/schema.py
@@ -1,0 +1,33 @@
+"""JSON schema for configuration files."""
+
+CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "app": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "log_level": {"type": "string"},
+            },
+            "required": ["name", "log_level"],
+        },
+        "database": {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string"},
+                "port": {"type": "integer"},
+                "name": {"type": "string"},
+            },
+            "required": ["host", "port", "name"],
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string"},
+                "port": {"type": "integer"},
+            },
+            "required": ["host", "port"],
+        },
+    },
+    "required": ["app", "database", "redis"],
+}

--- a/shared/config/vault.py
+++ b/shared/config/vault.py
@@ -1,0 +1,39 @@
+"""HashiCorp Vault integration."""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import hvac
+
+
+class VaultError(Exception):
+    """Raised when Vault operations fail."""
+
+
+class VaultClient:
+    """Simple Vault client wrapper."""
+
+    def __init__(self) -> None:
+        addr = os.getenv("VAULT_ADDR")
+        token = os.getenv("VAULT_TOKEN")
+        if not addr or not token:
+            raise VaultError("Vault configuration missing")
+        self._client = hvac.Client(url=addr, token=token)
+
+    async def get_secret(self, path: str, key: str) -> str:
+        """Fetch secret value asynchronously with retries."""
+        for _ in range(3):
+            try:
+                return await asyncio.to_thread(self._read_secret, path, key)
+            except hvac.exceptions.VaultError:
+                await asyncio.sleep(1)
+        raise VaultError(f"Unable to read secret {path}:{key}")
+
+    def _read_secret(self, path: str, key: str) -> str:
+        data = self._client.secrets.kv.read_secret_version(path=path)
+        value = data["data"]["data"].get(key)
+        if value is None:
+            raise VaultError(f"Key {key} not found in {path}")
+        return value

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -1,0 +1,27 @@
+from importlib import import_module
+import asyncio
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+config_mod = import_module("shared.config")
+
+
+@pytest.mark.asyncio
+async def test_load_config(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "local.yaml"
+    cfg_dir = tmp_path
+    cfg_file.write_text("app:\n  name: t\n  log_level: INFO\ndatabase:\n  host: h\n  port: 1\n  name: d\nredis:\n  host: r\n  port: 2\n")
+    monkeypatch.setenv("ALPHAFLOW_ENV", "local")
+    monkeypatch.setenv("CONFIG_DIR", str(cfg_dir))
+
+    class DummyVault:
+        async def get_secret(self, path: str, key: str) -> str:
+            return "v"
+
+    loader = config_mod.get_config_loader()
+    loader.vault_client = DummyVault()
+    cfg = await loader.load()
+    assert cfg["api_key"] == "v"

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -1,0 +1,37 @@
+from importlib import import_module
+from pathlib import Path
+import asyncio
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+loader_mod = import_module("shared.config.loader")
+vault_mod = import_module("shared.config.vault")
+
+
+class DummyVault(vault_mod.VaultClient):
+    def __init__(self) -> None:
+        pass
+
+    async def get_secret(self, path: str, key: str) -> str:  # type: ignore[override]
+        secrets = {"api_key": "test", "db_password": "pass"}
+        return secrets[key]
+
+
+def test_load_local_config(tmp_path):
+    cfg_file = tmp_path / "config/local.yaml"
+    cfg_file.parent.mkdir()
+    cfg_file.write_text(
+        "app:\n  name: t\n  log_level: INFO\ndatabase:\n  host: h\n  port: 1\n  name: d\nredis:\n  host: r\n  port: 2\n"
+    )
+    loader = loader_mod.ConfigLoader(env="local", config_dir=cfg_file.parent, vault_client=DummyVault())
+    cfg = asyncio.run(loader.load())
+    assert cfg["app"]["name"] == "t"
+    assert cfg["api_key"] == "test"
+
+
+def test_missing_config(tmp_path):
+    loader = loader_mod.ConfigLoader(env="missing", config_dir=tmp_path)
+    with pytest.raises(loader_mod.ConfigError):
+        asyncio.run(loader.load())

--- a/tests/config/test_reloader.py
+++ b/tests/config/test_reloader.py
@@ -1,0 +1,28 @@
+from importlib import import_module
+from pathlib import Path
+import asyncio
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+loader_mod = import_module("shared.config.loader")
+reloader_mod = import_module("shared.config.reloader")
+
+
+class DummyLoader(loader_mod.ConfigLoader):
+    async def load(self) -> dict:  # type: ignore[override]
+        return {"value": 1}
+
+
+@pytest.mark.asyncio
+async def test_reloader_triggers_callback(tmp_path):
+    loader = DummyLoader(env="local", config_dir=tmp_path)
+    result = {}
+
+    def cb(cfg):
+        result.update(cfg)
+
+    reloader = reloader_mod.ConfigReloader(loader, cb)
+    await reloader._reload()
+    assert result == {"value": 1}

--- a/tests/config/test_vault.py
+++ b/tests/config/test_vault.py
@@ -1,0 +1,40 @@
+from importlib import util
+from pathlib import Path
+import asyncio
+import pytest
+
+spec = util.spec_from_file_location(
+    "vault", Path("shared/config/vault.py").resolve()
+)
+vault_mod = util.module_from_spec(spec)
+spec.loader.exec_module(vault_mod)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls = []
+
+    class secrets:
+        class kv:
+            @staticmethod
+            def read_secret_version(path: str):
+                return {"data": {"data": {"api_key": "k"}}}
+
+
+class DummyVault(vault_mod.VaultClient):
+    def __init__(self) -> None:
+        self._client = FakeClient()
+
+
+@pytest.mark.asyncio
+async def test_get_secret():
+    client = DummyVault()
+    val = await client.get_secret("p", "api_key")
+    assert val == "k"
+
+
+@pytest.mark.asyncio
+async def test_missing_key_raises():
+    client = DummyVault()
+    with pytest.raises(vault_mod.VaultError):
+        await client.get_secret("p", "missing")

--- a/tools/config-validator.py
+++ b/tools/config-validator.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Validate all environment configurations."""
+from __future__ import annotations
+
+import asyncio
+
+from shared.config import get_config_loader
+
+
+class DummyVault:
+    async def get_secret(self, path: str, key: str) -> str:  # noqa: D401
+        """Return placeholder secret."""
+        return "placeholder"
+
+
+async def main() -> int:
+    for env in ("local", "staging", "production"):
+        loader = get_config_loader()
+        loader.env = env
+        loader.vault_client = DummyVault()
+        try:
+            await loader.load()
+            print(f"{env} configuration valid")
+        except Exception as exc:  # noqa: BLE001
+            print(f"{env} configuration invalid: {exc}")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
- implement configuration loader with Vault integration and schema validation
- provide hot reload utility
- add multi-environment YAML files
- introduce config validation script and Make targets
- add tests for configuration modules

## Testing
- `make validate-config`
- `make test-vault-integration`
- `pytest tests/config --cov=shared/config --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6847721da33c8322823b0ead8a05eabe