### PR TITLE
fix(strategy-engine): secure strategy loader with sandbox

### DIFF
--- a/services/strategy-engine/app.py
+++ b/services/strategy-engine/app.py
@@ -53,7 +53,12 @@ app = FastAPI()
 @app.post("/strategies")
 async def add_strategy(req: StrategyRequest) -> Dict[str, str]:
     try:
-        strat = load_strategy(req.path, req.path.split(".")[-1], req.position_size, **req.params)
+        strat = load_strategy(
+            req.path,
+            req.path.split(".")[-1],
+            req.position_size,
+            **req.params,
+        )
     except LoaderError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     manager.add(req.path, strat)

--- a/services/strategy-engine/strategies/loader.py
+++ b/services/strategy-engine/strategies/loader.py
@@ -1,22 +1,97 @@
-"""Strategy loader."""
+"""Secure strategy loader with sandboxing."""
 from __future__ import annotations
 
 import importlib
-from typing import Any, Type
+import logging
+import multiprocessing as mp
+import os
+import re
+from decimal import Decimal
+from typing import Any, Dict, Type
 
-from .base import BaseStrategy
+from .base import BaseStrategy, StrategyError
+from shared.utils.logging_utils import get_logger
+
+_PATH_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+
+DEFAULT_ALLOWLIST = {
+    "services.strategy-engine.strategies.moving_average.MovingAverageCrossover",
+    "services.strategy-engine.strategies.rsi_mean_reversion.RSIMeanReversion",
+    "services.strategy-engine.strategies.bollinger_squeeze.BollingerSqueeze",
+}
+
+ALLOWLIST = {
+    p.strip()
+    for p in os.getenv("STRATEGY_ALLOWLIST", "").split(",")
+    if p.strip()
+} or DEFAULT_ALLOWLIST
+
+logger = get_logger(__name__)
 
 
 class LoaderError(Exception):
     """Raised when loading strategies fails."""
 
 
-def load_strategy(path: str, *args: Any, **kwargs: Any) -> BaseStrategy:
-    """Load strategy class from module path."""
+def _sanitize_params(params: Dict[str, str]) -> Dict[str, Any]:
+    sanitized: Dict[str, Any] = {}
+    for key, val in params.items():
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            continue
+        try:
+            sanitized[key] = Decimal(val)
+        except Exception:
+            sanitized[key] = val
+    return sanitized
+
+
+class SandboxedStrategy(BaseStrategy):
+    """Wrapper that runs strategy in a separate process."""
+
+    def __init__(self, strategy: BaseStrategy, timeout: float = 1.0) -> None:
+        super().__init__(name=strategy.name, position_size=strategy.position_size)
+        self._strategy = strategy
+        self._timeout = timeout
+
+    def generate_signal(self, data: Any) -> Any:
+        def _run(q: mp.Queue, df: Any) -> None:
+            try:
+                q.put(self._strategy.generate_signal(df))
+            except Exception as exc:  # pragma: no cover - pass exception
+                q.put(exc)
+
+        q: mp.Queue = mp.Queue()
+        proc = mp.Process(target=_run, args=(q, data))
+        proc.start()
+        proc.join(self._timeout)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join()
+            raise StrategyError("Execution timed out")
+        result = q.get()
+        if isinstance(result, Exception):
+            raise StrategyError(str(result))
+        return result
+
+
+def load_strategy(
+    path: str, name: str, position_size: Decimal, timeout: float = 1.0, **params: str
+) -> BaseStrategy:
+    """Securely load a whitelisted strategy."""
+    if not _PATH_RE.fullmatch(path):
+        logger.warning("Rejected invalid path: %s", path)
+        raise LoaderError("Invalid path")
+    if path not in ALLOWLIST:
+        logger.warning("Strategy not allowed: %s", path)
+        raise LoaderError("Strategy not allowed")
     try:
         module_name, class_name = path.rsplit(".", 1)
         module = importlib.import_module(module_name)
         cls: Type[BaseStrategy] = getattr(module, class_name)
-        return cls(*args, **kwargs)
-    except (ImportError, AttributeError, TypeError) as exc:
+    except (ImportError, AttributeError) as exc:
         raise LoaderError(str(exc)) from exc
+    if not issubclass(cls, BaseStrategy):
+        raise LoaderError("Invalid strategy type")
+    strat = cls(name, position_size, **_sanitize_params(params))
+    logger.info("Loaded strategy %s", path)
+    return SandboxedStrategy(strat, timeout)

--- a/tests/strategy_engine/evil_strategy.py
+++ b/tests/strategy_engine/evil_strategy.py
@@ -1,0 +1,18 @@
+from decimal import Decimal
+from typing import Optional
+import pandas as pd
+from importlib import import_module
+
+BaseStrategy = import_module(
+    "services.strategy-engine.strategies.base"
+).BaseStrategy
+Signal = import_module("services.strategy-engine.signals.models").Signal
+import os
+
+class EvilStrategy(BaseStrategy):
+    def __init__(self, name: str, size: Decimal) -> None:
+        super().__init__(name, size)
+
+    def generate_signal(self, data: pd.DataFrame) -> Optional[Signal]:
+        open("/tmp/evil.txt", "w").write("hacked")
+        return None

--- a/tests/strategy_engine/hang_strategy.py
+++ b/tests/strategy_engine/hang_strategy.py
@@ -1,0 +1,17 @@
+from decimal import Decimal
+from typing import Optional
+import pandas as pd
+from importlib import import_module
+
+BaseStrategy = import_module(
+    "services.strategy-engine.strategies.base"
+).BaseStrategy
+Signal = import_module("services.strategy-engine.signals.models").Signal
+
+class HangStrategy(BaseStrategy):
+    def __init__(self, name: str, size: Decimal) -> None:
+        super().__init__(name, size)
+
+    def generate_signal(self, data: pd.DataFrame) -> Optional[Signal]:
+        while True:
+            pass

--- a/tests/strategy_engine/test_loader.py
+++ b/tests/strategy_engine/test_loader.py
@@ -1,11 +1,41 @@
+import importlib
 from decimal import Decimal
 
+import pandas as pd
+import pytest
+
 LOADER = "services.strategy-engine.strategies.loader"
-MA = "services.strategy-engine.strategies.moving_average"
+MA_PATH = (
+    "services.strategy-engine.strategies.moving_average.MovingAverageCrossover"
+)
+loader_mod = importlib.import_module(LOADER)
 
-loader_mod = __import__(LOADER, fromlist=["load_strategy"])
 
-
-def test_load_strategy():
-    strat = loader_mod.load_strategy(f"{MA}.MovingAverageCrossover", "test", Decimal("1"), 2, 3)
+def test_load_strategy_allowed():
+    strat = loader_mod.load_strategy(
+        MA_PATH,
+        "test",
+        Decimal("1"),
+        short_window="2",
+        long_window="3",
+    )
     assert strat.name == "test"
+
+
+def test_invalid_path_rejected():
+    with pytest.raises(loader_mod.LoaderError):
+        loader_mod.load_strategy("os.system;rm", "bad", Decimal("1"))
+
+
+def test_not_whitelisted():
+    with pytest.raises(loader_mod.LoaderError):
+        loader_mod.load_strategy("tests.strategy_engine.evil_strategy.EvilStrategy", "bad", Decimal("1"))
+
+
+def test_sandbox_timeout(monkeypatch):
+    path = "tests.strategy_engine.hang_strategy.HangStrategy"
+    monkeypatch.setenv("STRATEGY_ALLOWLIST", f"{MA_PATH},{path}")
+    importlib.reload(loader_mod)
+    strat = loader_mod.load_strategy(path, "hang", Decimal("1"), timeout=0.1)
+    with pytest.raises(loader_mod.StrategyError):
+        strat.generate_signal(pd.DataFrame())


### PR DESCRIPTION
## Summary
- harden strategy loading against code injection
- validate strategy modules via allowlist and sanitization
- sandbox strategy execution in a subprocess
- update API handler for new loader API
- add security tests covering malicious modules and timeout

## Testing
- `pytest -q`
- `pre-commit run --files services/strategy-engine/strategies/loader.py services/strategy-engine/app.py tests/strategy_engine/test_loader.py tests/strategy_engine/evil_strategy.py tests/strategy_engine/hang_strategy.py` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_68486208275c832297cdbae3b2d942bd