### PR TITLE
feat(security): add vault secret caching and update jwt

### DIFF
--- a/shared/config/vault.py
+++ b/shared/config/vault.py
@@ -1,11 +1,14 @@
 """HashiCorp Vault integration."""
+
 from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any
+from typing import Any, Dict, Tuple
 
 import hvac
+
+from shared.security.audit.logger import AuditLogger
 
 
 class VaultError(Exception):
@@ -13,20 +16,33 @@ class VaultError(Exception):
 
 
 class VaultClient:
-    """Simple Vault client wrapper."""
+    """Simple Vault client wrapper with caching and audit logging."""
 
-    def __init__(self) -> None:
+    def __init__(self, ttl: int = 300, logger: "AuditLogger | None" = None) -> None:
         addr = os.getenv("VAULT_ADDR")
         token = os.getenv("VAULT_TOKEN")
         if not addr or not token:
             raise VaultError("Vault configuration missing")
         self._client = hvac.Client(url=addr, token=token)
+        self._ttl = ttl
+        self._cache: Dict[Tuple[str, str], Tuple[str, float]] = {}
+        self._logger = logger
 
     async def get_secret(self, path: str, key: str) -> str:
-        """Fetch secret value asynchronously with retries."""
+        """Fetch secret value with caching and retries."""
+        cache_key = (path, key)
+        now = asyncio.get_event_loop().time()
+        if cache_key in self._cache:
+            val, exp = self._cache[cache_key]
+            if exp > now:
+                return val
         for _ in range(3):
             try:
-                return await asyncio.to_thread(self._read_secret, path, key)
+                val = await asyncio.to_thread(self._read_secret, path, key)
+                self._cache[cache_key] = (val, now + self._ttl)
+                if self._logger:
+                    self._logger.log(f"read {path}:{key}")
+                return val
             except hvac.exceptions.VaultError:
                 await asyncio.sleep(1)
         raise VaultError(f"Unable to read secret {path}:{key}")

--- a/tests/security/test_jwt.py
+++ b/tests/security/test_jwt.py
@@ -2,19 +2,38 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import os
 
-from shared.security.auth import generate_token, validate_token, AuthError, JWTTokenManager
+from shared.security.auth.jwt import set_key_manager
+
+from shared.security.auth import (
+    generate_token,
+    validate_token,
+    AuthError,
+    JWTTokenManager,
+)
 from shared.security.auth.fastapi import AuthMiddleware
 
 
-def test_token_generation_and_validation(monkeypatch):
-    monkeypatch.setenv("SERVICE_JWT_SECRET", "secret")
+def test_token_generation_and_validation():
+    class KM:
+        async def rotate(
+            self, service: str, env: str, key_field: str = "jwt_secret"
+        ) -> str:
+            return "secret"
+
+    set_key_manager(KM())
     token = generate_token("svc")
     claims = validate_token(token, "svc")
     assert claims["iss"] == "svc"
 
 
-def test_fastapi_auth_middleware(monkeypatch):
-    monkeypatch.setenv("SERVICE_JWT_SECRET", "secret")
+def test_fastapi_auth_middleware():
+    class KM:
+        async def rotate(
+            self, service: str, env: str, key_field: str = "jwt_secret"
+        ) -> str:
+            return "secret"
+
+    set_key_manager(KM())
     app = FastAPI()
     app.state.service_name = "svc"
     app.add_middleware(AuthMiddleware)
@@ -31,14 +50,18 @@ def test_fastapi_auth_middleware(monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
+
 class DummyKeyManager:
-    async def rotate(self, service: str, env: str, key_field: str = "jwt_secret") -> str:
+    async def rotate(
+        self, service: str, env: str, key_field: str = "jwt_secret"
+    ) -> str:
         return "newsecret"
 
-def test_token_manager_refresh(monkeypatch):
-    monkeypatch.setenv("SERVICE_JWT_SECRET", "secret")
+
+def test_token_manager_refresh():
     mgr = DummyKeyManager()
     tm = JWTTokenManager("svc", mgr)
     import asyncio
+
     asyncio.run(tm.refresh())
-    assert os.getenv("SERVICE_JWT_SECRET") == "newsecret"
+    assert tm._secret == "newsecret"

--- a/tests/security/test_vault_cache.py
+++ b/tests/security/test_vault_cache.py
@@ -1,0 +1,53 @@
+from importlib import util
+from pathlib import Path
+
+audit_spec = util.spec_from_file_location(
+    "audit", Path("shared/security/audit/logger.py").resolve()
+)
+audit_mod = util.module_from_spec(audit_spec)
+audit_spec.loader.exec_module(audit_mod)
+
+vault_spec = util.spec_from_file_location(
+    "vault", Path("shared/config/vault.py").resolve()
+)
+vault_mod = util.module_from_spec(vault_spec)
+vault_spec.loader.exec_module(vault_mod)
+
+
+CALLS = 0
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        pass
+
+    class secrets:
+        class kv:
+            @staticmethod
+            def read_secret_version(path: str):
+                global CALLS
+                CALLS += 1
+                return {"data": {"data": {"k": "v"}}}
+
+
+class DummyVault(vault_mod.VaultClient):
+    def __init__(self, ttl: int = 1, logger=None) -> None:
+        self._client = DummyClient()
+        self._ttl = ttl
+        self._cache = {}
+        self._logger = logger
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cache_and_audit(tmp_path):
+    log = tmp_path / "audit.log"
+    logger = audit_mod.AuditLogger(log)
+    client = DummyVault(logger=logger, ttl=60)
+    val1 = await client.get_secret("p", "k")
+    val2 = await client.get_secret("p", "k")
+    assert val1 == val2 == "v"
+    assert CALLS == 1
+    assert log.exists() and "read p:k" in log.read_text()


### PR DESCRIPTION
## Summary
- add caching and audit logging to Vault client
- refactor JWT utilities to fetch secrets from Vault
- add tests for vault caching and updated JWT behavior

## Testing
- `pytest tests/security -q`

------
https://chatgpt.com/codex/tasks/task_e_68486e3c73108322bec890c4b8d9d64c