### PR TITLE
feat(pnl): add real-time PnL tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ BINANCE_SECRET_KEY="YOUR_BINANCE_SECRET_KEY"
 POSTGRES_USER=alphaflow
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=alphaflow
+REDIS_URL=redis://localhost:6379/0
 REDIS_PASSWORD=changeme
 INFLUXDB_TOKEN=changeme
 # Risk Manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+redis
+backoff
 pre-commit
 pytest
 pytest-cov

--- a/services/pnl/__init__.py
+++ b/services/pnl/__init__.py
@@ -1,0 +1,5 @@
+"""PnL service package."""
+
+from .app import PnLService, PricingError
+
+__all__ = ["PnLService", "PricingError"]

--- a/services/pnl/app.py
+++ b/services/pnl/app.py
@@ -1,0 +1,101 @@
+"""Real-time P&L tracking with mark-to-market pricing."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Dict, List
+
+import backoff
+
+from .exceptions import PricingError
+
+
+@dataclass
+class Position:
+    """Represents an open trading position."""
+
+    quantity: Decimal = Decimal("0")
+    avg_price: Decimal = Decimal("0")
+    realized: Decimal = Decimal("0")
+    last_price: Decimal = Decimal("0")
+
+    def update(self, qty: Decimal, price: Decimal) -> None:
+        same_side = self.quantity * qty >= 0
+        if same_side:
+            total_qty = self.quantity + qty
+            if total_qty:
+                self.avg_price = (
+                    (self.avg_price * self.quantity) + (price * qty)
+                ) / total_qty
+            self.quantity = total_qty
+        else:
+            closed = min(abs(qty), abs(self.quantity))
+            sign = Decimal("1") if self.quantity > 0 else Decimal("-1")
+            self.realized += (price - self.avg_price) * closed * sign
+            self.quantity += qty
+            if self.quantity == 0:
+                self.avg_price = Decimal("0")
+            if abs(qty) > closed:
+                self.avg_price = price
+        self.last_price = price
+
+    def mark(self, price: Decimal) -> None:
+        if price <= 0:
+            raise PricingError(f"invalid price {price}")
+        self.last_price = price
+
+    @property
+    def unrealized(self) -> Decimal:
+        return (self.last_price - self.avg_price) * self.quantity
+
+
+class PnLService:
+    """Tracks portfolio P&L in real time."""
+
+    def __init__(self) -> None:
+        self.positions: Dict[str, Position] = {}
+        self.history: List[Dict[str, float]] = []
+
+    def on_fill(self, symbol: str, qty: Decimal, price: Decimal) -> None:
+        pos = self.positions.setdefault(symbol, Position())
+        pos.update(qty, price)
+
+    def on_price(self, symbol: str, price: Decimal) -> None:
+        pos = self.positions.get(symbol)
+        if not pos:
+            return
+        pos.mark(price)
+
+    def snapshot(self) -> Dict[str, float]:
+        realized = sum(p.realized for p in self.positions.values())
+        unrealized = sum(p.unrealized for p in self.positions.values())
+        snap = {
+            "realized": float(realized),
+            "unrealized": float(unrealized),
+            "total": float(realized + unrealized),
+        }
+        self.history.append(snap)
+        return snap
+
+    @backoff.on_exception(backoff.expo, Exception, max_tries=3)
+    async def listen_market_data(self, channel: str = "market") -> None:
+        import redis.asyncio as aioredis
+
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        redis = aioredis.from_url(url)
+        pubsub = redis.pubsub()
+        await pubsub.subscribe(channel)
+        async for msg in pubsub.listen():
+            if msg.get("type") != "message":
+                continue
+            try:
+                data = json.loads(msg["data"])
+                symbol = data["symbol"]
+                price = Decimal(str(data["price"]))
+                self.on_price(symbol, price)
+            except (KeyError, ValueError) as exc:
+                raise PricingError("invalid pricing data") from exc
+

--- a/services/pnl/exceptions.py
+++ b/services/pnl/exceptions.py
@@ -1,0 +1,5 @@
+"""PnL service exceptions."""
+
+
+class PricingError(Exception):
+    """Raised when pricing data is invalid or unavailable."""

--- a/tests/pnl/test_pnl_calculation.py
+++ b/tests/pnl/test_pnl_calculation.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+from pathlib import Path
+from decimal import Decimal
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "pnl", Path("services/pnl/__init__.py").resolve()
+)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["pnl"] = mod
+spec.loader.exec_module(mod)
+
+PnLService = mod.PnLService
+PricingError = mod.PricingError
+
+
+def test_unrealized_and_realized() -> None:
+    tracker = PnLService()
+    tracker.on_fill("BTC", Decimal("10"), Decimal("100"))
+    tracker.on_price("BTC", Decimal("110"))
+    snap = tracker.snapshot()
+    assert snap["realized"] == 0.0
+    assert snap["unrealized"] == 100.0
+
+    tracker.on_fill("BTC", Decimal("-5"), Decimal("115"))
+    tracker.on_price("BTC", Decimal("120"))
+    snap = tracker.snapshot()
+    assert snap["realized"] == 75.0
+    assert snap["unrealized"] == 100.0
+
+
+def test_invalid_price() -> None:
+    tracker = PnLService()
+    tracker.on_fill("ETH", Decimal("1"), Decimal("100"))
+    with pytest.raises(PricingError):
+        tracker.on_price("ETH", Decimal("-1"))
+
+
+def test_close_and_reverse() -> None:
+    tracker = PnLService()
+    tracker.on_fill("BTC", Decimal("5"), Decimal("100"))
+    tracker.on_fill("BTC", Decimal("-10"), Decimal("90"))
+    assert tracker.positions["BTC"].quantity == Decimal("-5")
+    tracker.on_price("UNUSED", Decimal("10"))  # no position, should noop
+    snap = tracker.snapshot()
+    assert snap["total"] == -50.0
+
+
+def test_close_position() -> None:
+    tracker = PnLService()
+    tracker.on_fill("BTC", Decimal("5"), Decimal("100"))
+    tracker.on_fill("BTC", Decimal("-5"), Decimal("110"))
+    assert tracker.positions["BTC"].quantity == 0
+    assert tracker.positions["BTC"].avg_price == Decimal("0")
+    snap = tracker.snapshot()
+    assert snap["realized"] == 50.0
+    assert snap["unrealized"] == 0.0
+
+
+


### PR DESCRIPTION
## Summary
- introduce PnL service for real-time position valuation
- ensure pricing data validation and error handling
- provide unit tests for PnL calculations
- expose REDIS_URL in environment example
- add redis and backoff to requirements

## Testing
- `pytest tests/pnl/test_pnl_calculation.py --cov=services/pnl --cov-report=term-missing`
- `make test` *(fails: Vault and strategy-engine tests require additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_6848718654bc8322b03017e8484406b5