### PR TITLE
feat(order): enhance lifecycle management

### DIFF
--- a/services/order-execution/api/client.go
+++ b/services/order-execution/api/client.go
@@ -1,58 +1,58 @@
 package api
 
 import (
-    "context"
-    "encoding/json"
-    "errors"
-    "net/http"
-    "net/url"
-    "os"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 
-    backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v4"
 )
 
 // Client wraps HTTP interactions with Binance REST API.
 type Client struct {
-    httpClient *http.Client
-    apiKey     string
-    secretKey  string
-    baseURL    string
+	httpClient *http.Client
+	apiKey     string
+	secretKey  string
+	baseURL    string
 }
 
 // New creates a new API client using environment variables.
 func New() (*Client, error) {
-    key := os.Getenv("BINANCE_API_KEY")
-    secret := os.Getenv("BINANCE_SECRET_KEY")
-    if key == "" || secret == "" {
-        return nil, errors.New("missing API credentials")
-    }
-    base := os.Getenv("BINANCE_REST_URL")
-    if base == "" {
-        base = "https://api.binance.com"
-    }
-    return &Client{
-        httpClient: &http.Client{Timeout: 5 * time.Second},
-        apiKey:     key,
-        secretKey:  secret,
-        baseURL:    base,
-    }, nil
+	key := os.Getenv("BINANCE_API_KEY")
+	secret := os.Getenv("BINANCE_SECRET_KEY")
+	if key == "" || secret == "" {
+		return nil, errors.New("missing API credentials")
+	}
+	base := os.Getenv("BINANCE_REST_URL")
+	if base == "" {
+		base = "https://api.binance.com"
+	}
+	return &Client{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		apiKey:     key,
+		secretKey:  secret,
+		baseURL:    base,
+	}, nil
 }
 
 // OrderRequest represents an order to submit.
 type OrderRequest struct {
-    Symbol   string
-    Side     string
-    Quantity string
-    Price    string
-    ID       string
+	Symbol   string
+	Side     string
+	Quantity string
+	Price    string
+	ID       string
 }
 
 // OrderResponse captures Binance order response.
 type OrderResponse struct {
-    OrderID int64 `json:"orderId"`
-    Status  string
+	OrderID int64 `json:"orderId"`
+	Status  string
 }
 
 // APIError describes failures returned by Binance.
@@ -62,38 +62,96 @@ func (e *APIError) Error() string { return e.Err.Error() }
 
 // PlaceOrder sends an order with retries and exponential backoff.
 func (c *Client) PlaceOrder(ctx context.Context, o OrderRequest) (*OrderResponse, error) {
-    var resp OrderResponse
-    operation := func() error {
-        data := url.Values{}
-        data.Set("symbol", o.Symbol)
-        data.Set("side", o.Side)
-        data.Set("quantity", o.Quantity)
-        data.Set("price", o.Price)
-        data.Set("newClientOrderId", o.ID)
-        r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v3/order", strings.NewReader(data.Encode()))
-        if err != nil {
-            return backoff.Permanent(err)
-        }
-        r.Header.Set("X-MBX-APIKEY", c.apiKey)
-        r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-        res, err := c.httpClient.Do(r)
-        if err != nil {
-            return err
-        }
-        defer res.Body.Close()
-        if res.StatusCode >= http.StatusInternalServerError {
-            return errors.New("server error")
-        }
-        if res.StatusCode != http.StatusOK {
-            return backoff.Permanent(&APIError{Err: errors.New(res.Status)})
-        }
-        return json.NewDecoder(res.Body).Decode(&resp)
-    }
-    b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
-    if err := backoff.Retry(operation, b); err != nil {
-        return nil, err
-    }
-    return &resp, nil
+	var resp OrderResponse
+	operation := func() error {
+		data := url.Values{}
+		data.Set("symbol", o.Symbol)
+		data.Set("side", o.Side)
+		data.Set("quantity", o.Quantity)
+		data.Set("price", o.Price)
+		data.Set("newClientOrderId", o.ID)
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v3/order", strings.NewReader(data.Encode()))
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		r.Header.Set("X-MBX-APIKEY", c.apiKey)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		res, err := c.httpClient.Do(r)
+		if err != nil {
+			return err
+		}
+		defer res.Body.Close()
+		if res.StatusCode >= http.StatusInternalServerError {
+			return errors.New("server error")
+		}
+		if res.StatusCode != http.StatusOK {
+			return backoff.Permanent(&APIError{Err: errors.New(res.Status)})
+		}
+		return json.NewDecoder(res.Body).Decode(&resp)
+	}
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	if err := backoff.Retry(operation, b); err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
+// GetOrder retrieves order status from the exchange.
+func (c *Client) GetOrder(ctx context.Context, id, symbol string) (*OrderResponse, error) {
+	var resp OrderResponse
+	operation := func() error {
+		q := url.Values{}
+		q.Set("symbol", symbol)
+		q.Set("origClientOrderId", id)
+		r, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v3/order?"+q.Encode(), nil)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		r.Header.Set("X-MBX-APIKEY", c.apiKey)
+		res, err := c.httpClient.Do(r)
+		if err != nil {
+			return err
+		}
+		defer res.Body.Close()
+		if res.StatusCode >= http.StatusInternalServerError {
+			return errors.New("server error")
+		}
+		if res.StatusCode != http.StatusOK {
+			return backoff.Permanent(&APIError{Err: errors.New(res.Status)})
+		}
+		return json.NewDecoder(res.Body).Decode(&resp)
+	}
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	if err := backoff.Retry(operation, b); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
 
+// CancelOrder cancels an open order on the exchange.
+func (c *Client) CancelOrder(ctx context.Context, id, symbol string) error {
+	operation := func() error {
+		q := url.Values{}
+		q.Set("symbol", symbol)
+		q.Set("origClientOrderId", id)
+		r, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/v3/order?"+q.Encode(), nil)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		r.Header.Set("X-MBX-APIKEY", c.apiKey)
+		res, err := c.httpClient.Do(r)
+		if err != nil {
+			return err
+		}
+		defer res.Body.Close()
+		if res.StatusCode >= http.StatusInternalServerError {
+			return errors.New("server error")
+		}
+		if res.StatusCode != http.StatusOK {
+			return backoff.Permanent(&APIError{Err: errors.New(res.Status)})
+		}
+		return nil
+	}
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	return backoff.Retry(operation, b)
+}

--- a/services/order-execution/api/client_test.go
+++ b/services/order-execution/api/client_test.go
@@ -1,43 +1,70 @@
 package api
 
 import (
-    "context"
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "sync/atomic"
-    "testing"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
 )
 
 func TestPlaceOrder_Retry(t *testing.T) {
-    var attempts int32
-    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if atomic.AddInt32(&attempts, 1) == 1 {
-            w.WriteHeader(http.StatusInternalServerError)
-            return
-        }
-        w.Header().Set("Content-Type", "application/json")
-        w.Write([]byte(`{"orderId":1,"status":"FILLED"}`))
-    }))
-    defer srv.Close()
-    os.Setenv("BINANCE_API_KEY", "k")
-    os.Setenv("BINANCE_SECRET_KEY", "s")
-    os.Setenv("BINANCE_REST_URL", srv.URL)
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"orderId":1,"status":"FILLED"}`))
+	}))
+	defer srv.Close()
+	os.Setenv("BINANCE_API_KEY", "k")
+	os.Setenv("BINANCE_SECRET_KEY", "s")
+	os.Setenv("BINANCE_REST_URL", srv.URL)
 
-    c, err := New()
-    if err != nil {
-        t.Fatal(err)
-    }
-    ctx := context.Background()
-    resp, err := c.PlaceOrder(ctx, OrderRequest{Symbol: "BTCUSDT", Side: "BUY", Quantity: "1", Price: "1", ID: "test"})
-    if err != nil {
-        t.Fatal(err)
-    }
-    if resp.OrderID != 1 || resp.Status != "FILLED" {
-        t.Fatalf("unexpected response %+v", resp)
-    }
-    if attempts < 2 {
-        t.Fatalf("expected retry, got %d attempts", attempts)
-    }
+	c, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	resp, err := c.PlaceOrder(ctx, OrderRequest{Symbol: "BTCUSDT", Side: "BUY", Quantity: "1", Price: "1", ID: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OrderID != 1 || resp.Status != "FILLED" {
+		t.Fatalf("unexpected response %+v", resp)
+	}
+	if attempts < 2 {
+		t.Fatalf("expected retry, got %d attempts", attempts)
+	}
 }
 
+func TestGetAndCancelOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Write([]byte(`{"orderId":2,"status":"FILLED"}`))
+	}))
+	defer srv.Close()
+	os.Setenv("BINANCE_API_KEY", "k")
+	os.Setenv("BINANCE_SECRET_KEY", "s")
+	os.Setenv("BINANCE_REST_URL", srv.URL)
+
+	c, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	resp, err := c.GetOrder(ctx, "id", "BTCUSDT")
+	if err != nil || resp.OrderID != 2 {
+		t.Fatalf("unexpected get response %+v err=%v", resp, err)
+	}
+	if err := c.CancelOrder(ctx, "id", "BTCUSDT"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/services/order-execution/orders/manager.go
+++ b/services/order-execution/orders/manager.go
@@ -1,30 +1,33 @@
 package orders
 
 import (
-    "errors"
-    "sync"
+	"errors"
+	"sync"
 
-    "github.com/google/uuid"
-    "github.com/shopspring/decimal"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 // Status represents order lifecycle stages.
 type Status string
 
 const (
-    Pending   Status = "pending"
-    Filled    Status = "filled"
-    Cancelled Status = "cancelled"
+	Pending   Status = "pending"
+	Partial   Status = "partial"
+	Filled    Status = "filled"
+	Cancelled Status = "cancelled"
 )
 
 // Order stores basic order data.
 type Order struct {
-    ID       string
-    Symbol   string
-    Side     string
-    Quantity decimal.Decimal
-    Price    decimal.Decimal
-    Status   Status
+	ID        string
+	Symbol    string
+	Side      string
+	Quantity  decimal.Decimal
+	Price     decimal.Decimal
+	FilledQty decimal.Decimal
+	AvgPrice  decimal.Decimal
+	Status    Status
 }
 
 // ErrDuplicate indicates order already exists.
@@ -32,48 +35,86 @@ var ErrDuplicate = errors.New("duplicate order")
 
 // Manager tracks orders and prevents duplicates.
 type Manager struct {
-    mu     sync.RWMutex
-    orders map[string]*Order
+	mu     sync.RWMutex
+	orders map[string]*Order
 }
 
 // NewManager creates a new order manager.
 func NewManager() *Manager {
-    return &Manager{orders: make(map[string]*Order)}
+	return &Manager{orders: make(map[string]*Order)}
 }
 
 // Create adds a new order and returns generated ID.
 func (m *Manager) Create(o *Order) (string, error) {
-    m.mu.Lock()
-    defer m.mu.Unlock()
-    if o.ID == "" {
-        o.ID = uuid.NewString()
-    }
-    if _, ok := m.orders[o.ID]; ok {
-        return "", ErrDuplicate
-    }
-    o.Status = Pending
-    m.orders[o.ID] = o
-    return o.ID, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if o.ID == "" {
+		o.ID = uuid.NewString()
+	}
+	if _, ok := m.orders[o.ID]; ok {
+		return "", ErrDuplicate
+	}
+	o.Status = Pending
+	m.orders[o.ID] = o
+	return o.ID, nil
 }
 
 // UpdateStatus updates existing order state.
 func (m *Manager) UpdateStatus(id string, status Status) error {
-    m.mu.Lock()
-    defer m.mu.Unlock()
-    ord, ok := m.orders[id]
-    if !ok {
-        return errors.New("order not found")
-    }
-    ord.Status = status
-    return nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ord, ok := m.orders[id]
+	if !ok {
+		return errors.New("order not found")
+	}
+	ord.Status = status
+	return nil
 }
 
 // Get returns an order by id.
 func (m *Manager) Get(id string) (*Order, bool) {
-    m.mu.RLock()
-    defer m.mu.RUnlock()
-    ord, ok := m.orders[id]
-    return ord, ok
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ord, ok := m.orders[id]
+	return ord, ok
 }
 
+// AddFill records a fill on an order and updates status.
+func (m *Manager) AddFill(id string, qty, price decimal.Decimal) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ord, ok := m.orders[id]
+	if !ok {
+		return errors.New("order not found")
+	}
+	totalQty := ord.FilledQty.Add(qty)
+	if totalQty.GreaterThan(ord.Quantity) {
+		return errors.New("fill exceeds quantity")
+	}
+	if !totalQty.IsZero() {
+		ord.AvgPrice = ord.AvgPrice.Mul(ord.FilledQty).Add(price.Mul(qty)).Div(totalQty)
+	}
+	ord.FilledQty = totalQty
+	switch {
+	case ord.FilledQty.Equal(ord.Quantity):
+		ord.Status = Filled
+	case ord.FilledQty.GreaterThan(decimal.Zero):
+		ord.Status = Partial
+	}
+	return nil
+}
 
+// Cancel marks the order as cancelled.
+func (m *Manager) Cancel(id string) error {
+	return m.UpdateStatus(id, Cancelled)
+}
+
+// Reconcile updates the order based on exchange status.
+func (m *Manager) Reconcile(id string, status Status) error {
+	switch status {
+	case Filled, Cancelled:
+		return m.UpdateStatus(id, status)
+	default:
+		return nil
+	}
+}

--- a/services/order-execution/orders/manager_test.go
+++ b/services/order-execution/orders/manager_test.go
@@ -1,26 +1,62 @@
 package orders
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/shopspring/decimal"
+	"github.com/shopspring/decimal"
 )
 
 func TestManager_CreateAndUpdate(t *testing.T) {
-    m := NewManager()
-    id, err := m.Create(&Order{Symbol: "BTCUSDT", Side: "BUY", Quantity: decimal.NewFromInt(1), Price: decimal.NewFromInt(1)})
-    if err != nil {
-        t.Fatal(err)
-    }
-    if _, err := m.Create(&Order{ID: id}); err == nil {
-        t.Fatal("expected duplicate error")
-    }
-    if err := m.UpdateStatus(id, Filled); err != nil {
-        t.Fatal(err)
-    }
-    ord, ok := m.Get(id)
-    if !ok || ord.Status != Filled {
-        t.Fatal("status not updated")
-    }
+	m := NewManager()
+	id, err := m.Create(&Order{Symbol: "BTCUSDT", Side: "BUY", Quantity: decimal.NewFromInt(1), Price: decimal.NewFromInt(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Create(&Order{ID: id}); err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	if err := m.UpdateStatus(id, Filled); err != nil {
+		t.Fatal(err)
+	}
+	ord, ok := m.Get(id)
+	if !ok || ord.Status != Filled {
+		t.Fatal("status not updated")
+	}
 }
 
+func TestManager_FillAndReconcile(t *testing.T) {
+	m := NewManager()
+	id, err := m.Create(&Order{Symbol: "ETHUSDT", Side: "BUY", Quantity: decimal.NewFromInt(2), Price: decimal.NewFromInt(10)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AddFill(id, decimal.NewFromInt(1), decimal.NewFromInt(10)); err != nil {
+		t.Fatal(err)
+	}
+	ord, _ := m.Get(id)
+	if ord.Status != Partial {
+		t.Fatalf("expected partial got %s", ord.Status)
+	}
+	if err := m.Reconcile(id, Filled); err != nil {
+		t.Fatal(err)
+	}
+	ord, _ = m.Get(id)
+	if ord.Status != Filled {
+		t.Fatalf("expected filled got %s", ord.Status)
+	}
+}
+
+func TestManager_Cancel(t *testing.T) {
+	m := NewManager()
+	id, err := m.Create(&Order{Symbol: "BTCUSDT", Side: "BUY", Quantity: decimal.NewFromInt(1), Price: decimal.NewFromInt(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Cancel(id); err != nil {
+		t.Fatal(err)
+	}
+	ord, _ := m.Get(id)
+	if ord.Status != Cancelled {
+		t.Fatalf("expected cancelled got %s", ord.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- add Partial order status with fill tracking
- support cancel & reconciliation helpers
- extend API client with GetOrder and CancelOrder
- cover partial fills and cancel flows

## Testing
- `go test ./... -cover`
- `make security-scan` *(fails: panic in gitleaks config)*
- `make test` *(fails: missing fastapi dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684873de9fa48322997ddaf6b4cae11c