### PR TITLE
feat(risk): add realtime monitoring and margin tools

### DIFF
--- a/services/pnl/app.py
+++ b/services/pnl/app.py
@@ -59,6 +59,11 @@ class PnLService:
         self.positions: Dict[str, Position] = {}
         self.history: List[Dict[str, float]] = []
 
+    @property
+    def prices(self) -> Dict[str, Decimal]:
+        """Current marked prices for all positions."""
+        return {sym: pos.last_price for sym, pos in self.positions.items()}
+
     def on_fill(self, symbol: str, qty: Decimal, price: Decimal) -> None:
         pos = self.positions.setdefault(symbol, Position())
         pos.update(qty, price)

--- a/services/risk-manager/app.py
+++ b/services/risk-manager/app.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from decimal import Decimal
-from typing import List
+from typing import Dict, List, Optional
 
 from .circuit_breakers.drawdown import DrawdownCircuitBreaker
 from .exceptions import CircuitBreakerTripped, RiskLimitBreached, ValidationError
@@ -13,15 +14,23 @@ from .limits.daily_loss import DailyLossLimit
 from .limits.drawdown import DrawdownLimit
 from .limits.position import PositionLimit
 from .limits.velocity import VelocityLimit
-from .monitors.portfolio import Portfolio
+from .monitors.portfolio import Portfolio, Position
+from .monitors.realtime import RealTimeMonitor
+from services.pnl import PnLService
 from .reporting.reporter import Reporter
 
 
 class RiskManager:
     """Main risk manager entry point."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        pnl_service: Optional[PnLService] = None,
+        alert_queue: Optional[asyncio.Queue[str]] = None,
+    ) -> None:
         self.portfolio = Portfolio()
+        self.pnl_service = pnl_service or PnLService()
+        self.alerts = RealTimeMonitor(alert_queue or asyncio.Queue())
         self.limits: List = [
             PositionLimit(
                 Decimal(os.getenv("POSITION_LIMIT_SYMBOL", "10")),
@@ -46,12 +55,40 @@ class RiskManager:
         for cb in self.circuit_breakers:
             cb.check(self.portfolio)
         for limit in self.limits:
-            reason = limit.check(order, self.portfolio)
+            reason = limit.check(order, self.portfolio, self.pnl_service.prices)
             if reason:
+                await self.alerts.alert(reason)
                 raise RiskLimitBreached(reason)
 
     async def on_fill(self, order: Order) -> None:
         self.portfolio.update(order.symbol, order.quantity, order.price)
+        self.pnl_service.on_fill(order.symbol, order.quantity, order.price)
 
     async def report(self) -> dict:
         return await self.reporter.snapshot(self.portfolio)
+
+    def margin(self) -> Decimal:
+        """Calculate portfolio margin requirement."""
+        return sum(
+            abs(p.quantity * p.last_price)
+            for p in self.pnl_service.positions.values()
+        ) * Decimal("0.1")
+
+    def stress_test(self, shocks: Dict[str, Decimal]) -> Decimal:
+        """Apply price shocks and return projected PnL."""
+        pnl = Decimal("0")
+        for sym, pos in self.pnl_service.positions.items():
+            shock = shocks.get(sym, Decimal("0"))
+            pnl += pos.quantity * (pos.last_price + shock - pos.last_price)
+        return pnl
+
+    def rebalance(self, targets: Dict[str, Decimal]) -> List[Order]:
+        """Generate orders to match target quantities."""
+        orders: List[Order] = []
+        for sym, target in targets.items():
+            current = self.portfolio.positions.get(sym, Position()).quantity
+            diff = target - current
+            if diff:
+                price = self.pnl_service.prices.get(sym, Decimal("0"))
+                orders.append(Order(symbol=sym, quantity=diff, price=price, side="BUY" if diff > 0 else "SELL"))
+        return orders

--- a/services/risk-manager/limits/base.py
+++ b/services/risk-manager/limits/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional
 
 from ..monitors.portfolio import Portfolio
 
@@ -23,6 +23,8 @@ class BaseLimit(ABC):
     """Interface for all risk limits."""
 
     @abstractmethod
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         """Return reason string if breached."""
 

--- a/services/risk-manager/limits/concentration.py
+++ b/services/risk-manager/limits/concentration.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional
 
 from .base import BaseLimit, Order
 from ..monitors.portfolio import Portfolio
@@ -14,17 +14,22 @@ class ConcentrationLimit(BaseLimit):
     def __init__(self, max_percent: Decimal) -> None:
         self.max_percent = max_percent
 
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         total_value = sum(
-            abs(p.quantity * p.avg_price) for p in portfolio.positions.values()
-        ) + abs(order.quantity * order.price)
+            abs(p.quantity * prices.get(sym, p.avg_price))
+            for sym, p in portfolio.positions.items()
+        ) + abs(order.quantity * prices.get(order.symbol, order.price))
         if total_value == 0:
             return None
         existing = portfolio.positions.get(order.symbol)
         existing_value = (
-            abs(existing.quantity * existing.avg_price) if existing else Decimal("0")
+            abs(existing.quantity * prices.get(order.symbol, existing.avg_price))
+            if existing
+            else Decimal("0")
         )
-        sym_value = existing_value + abs(order.quantity * order.price)
+        sym_value = existing_value + abs(order.quantity * prices.get(order.symbol, order.price))
         if (sym_value / total_value) > self.max_percent:
             return "concentration limit"
         return None

--- a/services/risk-manager/limits/daily_loss.py
+++ b/services/risk-manager/limits/daily_loss.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional
 
 from .base import BaseLimit, Order
 from ..monitors.portfolio import Portfolio
@@ -14,7 +14,9 @@ class DailyLossLimit(BaseLimit):
     def __init__(self, max_loss: Decimal) -> None:
         self.max_loss = max_loss
 
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         if portfolio.pnl < -self.max_loss:
             return "daily loss limit"
         return None

--- a/services/risk-manager/limits/drawdown.py
+++ b/services/risk-manager/limits/drawdown.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional
 
 from .base import BaseLimit, Order
 from ..monitors.portfolio import Portfolio
@@ -15,7 +15,9 @@ class DrawdownLimit(BaseLimit):
         self.max_drawdown = max_drawdown
         self.high_watermark = Decimal("0")
 
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         pnl = portfolio.pnl
         if pnl > self.high_watermark:
             self.high_watermark = pnl

--- a/services/risk-manager/limits/position.py
+++ b/services/risk-manager/limits/position.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional
 
 from .base import BaseLimit, Order
 from ..monitors.portfolio import Portfolio
@@ -15,7 +15,9 @@ class PositionLimit(BaseLimit):
         self.symbol_limit = symbol_limit
         self.total_limit = total_limit
 
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         sym_qty = portfolio.positions.get(order.symbol, None)
         current = sym_qty.quantity if sym_qty else Decimal("0")
         if abs(current + order.quantity) > self.symbol_limit:

--- a/services/risk-manager/limits/velocity.py
+++ b/services/risk-manager/limits/velocity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import time
 from collections import deque
-from typing import Deque, Optional
+from typing import Deque, Dict, Optional
 
 from .base import BaseLimit, Order
 from ..monitors.portfolio import Portfolio
@@ -17,7 +17,9 @@ class VelocityLimit(BaseLimit):
         self.window_sec = window_sec
         self.history: Deque[float] = deque()
 
-    def check(self, order: Order, portfolio: Portfolio) -> Optional[str]:
+    def check(
+        self, order: Order, portfolio: Portfolio, prices: Dict[str, Decimal]
+    ) -> Optional[str]:
         now = time.time()
         self.history.append(now)
         while self.history and now - self.history[0] > self.window_sec:

--- a/services/risk-manager/monitors/realtime.py
+++ b/services/risk-manager/monitors/realtime.py
@@ -1,0 +1,16 @@
+"""Real-time risk alert monitor."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+
+@dataclass
+class RealTimeMonitor:
+    """Broadcasts risk alerts through an asyncio queue."""
+
+    queue: asyncio.Queue[str]
+
+    async def alert(self, message: str) -> None:
+        """Send alert asynchronously."""
+        await self.queue.put(message)

--- a/services/risk-manager/reporting/reporter.py
+++ b/services/risk-manager/reporting/reporter.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Dict
+from decimal import Decimal
 
 from ..monitors.portfolio import Portfolio
 
@@ -10,7 +11,11 @@ class Reporter:
     """Provides basic risk metrics."""
 
     async def snapshot(self, portfolio: Portfolio) -> Dict[str, float]:
+        margin = sum(
+            abs(p.quantity * p.avg_price) for p in portfolio.positions.values()
+        ) * Decimal("0.1")
         return {
             "pnl": float(portfolio.pnl),
             "positions": len(portfolio.positions),
+            "margin": float(margin),
         }

--- a/tests/risk_manager/test_realtime.py
+++ b/tests/risk_manager/test_realtime.py
@@ -1,0 +1,27 @@
+import importlib.util
+import sys
+from pathlib import Path
+from decimal import Decimal
+import asyncio
+import pytest
+
+
+def load_risk_manager():
+    spec = importlib.util.spec_from_file_location("risk_manager", Path("services/risk-manager/__init__.py").resolve())
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["risk_manager"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.asyncio
+async def test_alert_queue_populated():
+    risk_mod = load_risk_manager()
+    q: asyncio.Queue[str] = asyncio.Queue()
+    manager = risk_mod.RiskManager(alert_queue=q)
+    order = risk_mod.Order("BTC", Decimal("11"), Decimal("1"), "BUY")
+    with pytest.raises(risk_mod.exceptions_mod.RiskLimitBreached):
+        await manager.validate_order(order)
+    assert not q.empty()
+    alert = await q.get()
+    assert "limit" in alert


### PR DESCRIPTION
## Summary
- add realtime risk alert monitor
- extend risk limits to use live prices
- integrate PnL service with RiskManager
- compute margin and provide stress testing/rebalancing helpers
- expand reporter with margin metric
- test realtime alert queue

## Testing
- `pre-commit run --files services/risk-manager/limits/base.py services/risk-manager/limits/concentration.py services/risk-manager/limits/daily_loss.py services/risk-manager/limits/drawdown.py services/risk-manager/limits/velocity.py services/risk-manager/limits/position.py services/risk-manager/app.py services/pnl/app.py services/risk-manager/reporting/reporter.py services/risk-manager/monitors/realtime.py tests/risk_manager/test_realtime.py --hook-stage manual` *(fails: requires GitHub access)*
- `pytest tests/risk_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_684880ee30d88322935d44fd8ace9447