### PR TITLE
feat(market-data): improve data handling with validation

### DIFF
--- a/services/market-data/cache/cache.go
+++ b/services/market-data/cache/cache.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+type entry struct {
+	data []byte
+	exp  time.Time
+}
+
+type Cache struct {
+	ttl time.Duration
+	m   sync.Map
+}
+
+func New(ttl time.Duration) *Cache {
+	return &Cache{ttl: ttl}
+}
+
+func (c *Cache) Set(key string, val []byte) {
+	c.m.Store(key, entry{data: val, exp: time.Now().Add(c.ttl)})
+}
+
+func (c *Cache) Get(key string) ([]byte, bool) {
+	v, ok := c.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	e := v.(entry)
+	if time.Now().After(e.exp) {
+		c.m.Delete(key)
+		return nil, false
+	}
+	return e.data, true
+}

--- a/services/market-data/cache/cache_test.go
+++ b/services/market-data/cache/cache_test.go
@@ -1,0 +1,18 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCache(t *testing.T) {
+	c := New(100 * time.Millisecond)
+	c.Set("k", []byte("v"))
+	if v, ok := c.Get("k"); !ok || string(v) != "v" {
+		t.Fatal("cache miss")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("expected expire")
+	}
+}

--- a/services/market-data/calendar/calendar.go
+++ b/services/market-data/calendar/calendar.go
@@ -1,0 +1,26 @@
+package calendar
+
+import "time"
+
+type Calendar struct {
+	Open  time.Duration
+	Close time.Duration
+}
+
+func New(open, close string) (Calendar, error) {
+	o, err := time.Parse("15:04", open)
+	if err != nil {
+		return Calendar{}, err
+	}
+	c, err := time.Parse("15:04", close)
+	if err != nil {
+		return Calendar{}, err
+	}
+	return Calendar{Open: time.Duration(o.Hour())*time.Hour + time.Duration(o.Minute())*time.Minute,
+		Close: time.Duration(c.Hour())*time.Hour + time.Duration(c.Minute())*time.Minute}, nil
+}
+
+func (cal Calendar) IsOpen(t time.Time) bool {
+	d := time.Duration(t.Hour())*time.Hour + time.Duration(t.Minute())*time.Minute
+	return d >= cal.Open && d <= cal.Close
+}

--- a/services/market-data/calendar/calendar_test.go
+++ b/services/market-data/calendar/calendar_test.go
@@ -1,0 +1,19 @@
+package calendar
+
+import "testing"
+import "time"
+
+func TestCalendar(t *testing.T) {
+	c, err := New("09:30", "16:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	open := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	if !c.IsOpen(open) {
+		t.Fatal("should be open")
+	}
+	closed := time.Date(2023, 1, 1, 17, 0, 0, 0, time.UTC)
+	if c.IsOpen(closed) {
+		t.Fatal("should be closed")
+	}
+}

--- a/services/market-data/config/config.go
+++ b/services/market-data/config/config.go
@@ -7,10 +7,13 @@ import (
 )
 
 type Config struct {
-	Symbols   []string
-	RedisAddr string
-	Channel   string
-	BaseURL   string
+        Symbols   []string
+        RedisAddr string
+        Channel   string
+        BaseURL   string
+        SecondaryURL string
+        MarketOpen   string
+        MarketClose  string
 }
 
 func Load() (*Config, error) {
@@ -26,9 +29,18 @@ func Load() (*Config, error) {
 	if channel == "" {
 		channel = "market-data"
 	}
-	base := os.Getenv("BINANCE_WS")
-	if base == "" {
-		base = "wss://stream.binance.com:9443"
-	}
-	return &Config{Symbols: strings.Split(symbols, ","), RedisAddr: addr, Channel: channel, BaseURL: base}, nil
+       base := os.Getenv("BINANCE_WS")
+       if base == "" {
+               base = "wss://stream.binance.com:9443"
+       }
+       sec := os.Getenv("SECONDARY_WS")
+       open := os.Getenv("MARKET_OPEN")
+       if open == "" {
+               open = "00:00"
+       }
+       close := os.Getenv("MARKET_CLOSE")
+       if close == "" {
+               close = "23:59"
+       }
+       return &Config{Symbols: strings.Split(symbols, ","), RedisAddr: addr, Channel: channel, BaseURL: base, SecondaryURL: sec, MarketOpen: open, MarketClose: close}, nil
 }

--- a/services/market-data/go.mod
+++ b/services/market-data/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt/v5 v5.2.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/prometheus/client_golang v1.15.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/services/market-data/go.sum
+++ b/services/market-data/go.sum
@@ -23,12 +23,16 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/services/market-data/main.go
+++ b/services/market-data/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	pub := publisher.NewRedisPublisher(cfg.RedisAddr, cfg.Channel)
-	client := ws.New(cfg, pub)
+	client := ws.New(cfg, pub, "marketdata.db")
 	if err := client.Start(); err != nil {
 		log.Fatal(err)
 	}

--- a/services/market-data/storage/storage.go
+++ b/services/market-data/storage/storage.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"database/sql"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type Store struct {
+	db *sql.DB
+}
+
+func (s *Store) DB() *sql.DB { return s.db }
+
+func New(path string) (*Store, error) {
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS ticks(id INTEGER PRIMARY KEY AUTOINCREMENT,symbol TEXT,data TEXT,ts DATETIME DEFAULT CURRENT_TIMESTAMP)`); err != nil {
+		return nil, err
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Save(symbol string, data []byte) error {
+	_, err := s.db.Exec(`INSERT INTO ticks(symbol,data) VALUES(?,?)`, symbol, string(data))
+	return err
+}
+
+func (s *Store) History(symbol string, limit int) ([][]byte, error) {
+	rows, err := s.db.Query(`SELECT data FROM ticks WHERE symbol=? ORDER BY id DESC LIMIT ?`, symbol, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res [][]byte
+	for rows.Next() {
+		var d string
+		if err := rows.Scan(&d); err != nil {
+			return nil, err
+		}
+		res = append(res, []byte(d))
+	}
+	return res, nil
+}

--- a/services/market-data/storage/storage_test.go
+++ b/services/market-data/storage/storage_test.go
@@ -1,0 +1,20 @@
+package storage
+
+import "testing"
+
+func TestStore(t *testing.T) {
+	s, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save("BTCUSDT", []byte("test")); err != nil {
+		t.Fatal(err)
+	}
+	hist, err := s.History("BTCUSDT", 1)
+	if err != nil || len(hist) != 1 {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if string(hist[0]) != "test" {
+		t.Fatal("wrong data")
+	}
+}

--- a/services/market-data/validation/validator.go
+++ b/services/market-data/validation/validator.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"sync"
+)
+
+type Validator struct {
+	mu  sync.Mutex
+	avg map[string]float64
+}
+
+func New() *Validator {
+	return &Validator{avg: make(map[string]float64)}
+}
+
+func (v *Validator) Validate(msg []byte) ([]byte, string, error) {
+	var data map[string]interface{}
+	if err := json.Unmarshal(msg, &data); err != nil {
+		return nil, "", err
+	}
+	symbol, _ := data["s"].(string)
+	price, ok := data["p"].(float64)
+	if !ok || price <= 0 || math.IsNaN(price) {
+		return nil, symbol, errors.New("invalid price")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	avg := v.avg[symbol]
+	if avg == 0 {
+		v.avg[symbol] = price
+	} else {
+		if math.Abs(price-avg)/avg > 0.2 {
+			return nil, symbol, errors.New("outlier detected")
+		}
+		v.avg[symbol] = 0.8*avg + 0.2*price
+	}
+	out, err := json.Marshal(data)
+	return out, symbol, err
+}

--- a/services/market-data/validation/validator_test.go
+++ b/services/market-data/validation/validator_test.go
@@ -1,0 +1,20 @@
+package validation
+
+import "testing"
+
+func TestValidate(t *testing.T) {
+	v := New()
+	msg := []byte(`{"s":"BTCUSDT","p":100}`)
+	out, sym, err := v.Validate(msg)
+	if err != nil || sym != "BTCUSDT" || len(out) == 0 {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bad := []byte(`{"s":"BTCUSDT","p":-1}`)
+	if _, _, err := v.Validate(bad); err == nil {
+		t.Fatal("expected error")
+	}
+	outlier := []byte(`{"s":"BTCUSDT","p":500}`)
+	if _, _, err := v.Validate(outlier); err == nil {
+		t.Fatal("expected outlier error")
+	}
+}

--- a/services/market-data/websocket/client_test.go
+++ b/services/market-data/websocket/client_test.go
@@ -25,21 +25,21 @@ func TestClientReceives(t *testing.T) {
 		up := websocket.Upgrader{}
 		c, _ := up.Upgrade(w, r, nil)
 		defer c.Close()
-		c.WriteMessage(websocket.TextMessage, []byte("{\"test\":1}"))
+		c.WriteMessage(websocket.TextMessage, []byte("{\"s\":\"BTCUSDT\",\"p\":100}"))
 		time.Sleep(50 * time.Millisecond)
 	}))
 	defer srv.Close()
 
 	url := "ws" + srv.URL[4:]
-	cfg := &config.Config{Symbols: []string{"btcusdt"}, BaseURL: url}
+	cfg := &config.Config{Symbols: []string{"btcusdt"}, BaseURL: url, MarketOpen: "00:00", MarketClose: "23:59"}
 	pub := &mockPublisher{msgs: make(chan []byte, 1)}
-	client := New(cfg, pub)
+	client := New(cfg, pub, ":memory:")
 	require.NoError(t, client.Start())
 	defer client.Stop()
 	select {
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	case msg := <-pub.msgs:
-		require.JSONEq(t, "{\"test\":1}", string(msg))
+		require.JSONEq(t, "{\"s\":\"BTCUSDT\",\"p\":100}", string(msg))
 	}
 }


### PR DESCRIPTION
## Summary
- add cache, calendar, storage, validation packages for market-data service
- implement failover, caching and validation in websocket client
- persist historical data and support trading calendar
- update configuration for new options
- test new features

## Testing
- `make test-market-data`
- `make lint` *(fails: pre-commit prompted for GitHub credentials)*
- `pytest -q` *(fails: 16 errors during collection)*
- `make security-scan` *(fails: gitleaks: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6848844a8b148322932ed38607ee6375